### PR TITLE
Use now() instead of the epoch if indicator has no timestamp

### DIFF
--- a/src/cbopensource/connectors/taxii/bridge.py
+++ b/src/cbopensource/connectors/taxii/bridge.py
@@ -313,7 +313,7 @@ class CbTaxiiFeedConverter(object):
                                     score = default_score
 
                                 if not indicator.timestamp:
-                                    timestamp = 0
+                                    timestamp = int(datetime.datetime.now().timestamp())
                                 else:
                                     timestamp = int((indicator.timestamp - EPOCH).total_seconds())
 


### PR DESCRIPTION
The timestamp variable is used for setting the ThreatReport timestamp value. In the GUI this shows as the "Last Updated" timestamp. If no timestamp is available from the TAXII source, it makes more sense to use the time it was polled from EDR. Sorting by "Last Updated" in the GUI makes it impossible to tell which ThreatReports are newest otherwise (the same is true for "Date Created" - more on that below).

It's also worth noting that EDR must be using this timestamp as opposed to now() when setting the create_time on the ThreatReport, as we now have ThreatReport objects where the create_time is 0 because timestamp was set to 0. This makes it especially important to use now() as opposed to epoch for the timestamp value.

@dseidel-b9 